### PR TITLE
Code reorganization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,33 @@
+AllCops:
+  Include:
+    - '**/Rakefile'
+
+#Style/HashSyntax:
+  #EnforcedStyle: hash_rockets
+
+Style/GuardClause:
+  Enabled: false
+
+Style/LineLength:
+  Max: 100
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/ClassLength:
+  Enabled: false
+
+Style/MethodLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false

--- a/kinto_box.gemspec
+++ b/kinto_box.gemspec
@@ -4,33 +4,35 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kinto_box/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "kinto_box"
+  spec.name          = 'kinto_box'
   spec.version       = KintoBox::VERSION
-  spec.authors       = ["Kavya Sukumar"]
-  spec.email         = ["Kavya.Sukumar@voxmedia.com"]
+  spec.authors       = ['Kavya Sukumar']
+  spec.email         = ['Kavya.Sukumar@voxmedia.com']
 
-  spec.summary       = %q{Kinto http client in ruby}
-  spec.description   = %q{Kinto http client in ruby}
-  spec.homepage      = "http://github.com/voxmedia/kinto_box"
-  spec.license       = "BSD"
+  spec.summary       = 'Kinto http client in ruby'
+  spec.description   = 'Kinto http client in ruby'
+  spec.homepage      = 'http://github.com/voxmedia/kinto_box'
+  spec.license       = 'BSD'
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
+    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'httparty', '~> 0.13.7'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'json', '~> 1.8', '>= 1.8.3'
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rdoc'
+  spec.add_development_dependency 'rubocop'
 end

--- a/lib/kinto_box/errors.rb
+++ b/lib/kinto_box/errors.rb
@@ -28,34 +28,4 @@ module KintoBox
 
   # Raised when there is some sort of error on the server
   class ServerError < Error; end
-
-  class ResponseHandler
-    def self.handle(resp)
-      if [200, 201].include? resp.code
-        JSON.parse resp.body
-      elsif [202, 204].include? resp.code
-        true
-      elsif resp.code == 400
-        raise BadRequest, resp
-      elsif resp.code == 404
-        raise NotFound, resp
-      elsif resp.code == 401
-        raise NotAllowed, resp
-      elsif resp.code == 403
-        raise NotAuthorized, resp
-      elsif resp.code >= 500
-        raise ServerError, resp
-      else
-        raise Error, resp
-      end
-    end
-
-    def self.get_response_head(resp)
-      if [200, 201].include? resp.code
-        resp.headers
-      else
-        raise BadRequest, resp
-      end
-    end
-  end
 end

--- a/lib/kinto_box/kinto_batch_request.rb
+++ b/lib/kinto_box/kinto_batch_request.rb
@@ -1,30 +1,26 @@
-require 'kinto_box/kinto_collection'
-require 'kinto_box/kinto_object'
 require 'kinto_box/kinto_request'
-
 module KintoBox
-  class KintoBatchRequest
+  class KintoBatchRequest < KintoRequest
+    attr_reader :requests
 
-    def initialize(kinto_client)
-      @kinto_client = kinto_client
-      @request_data = {'defaults' => {
-                        'method'=> 'POST',
-                        'path'=> '/'
-                       },
-                       'requests' =>[]
-      }
-      @requests = @request_data['requests']
+    def initialize(client)
+      @requests = []
+      super(client, 'POST', '/batch')
     end
 
     def add_request(request)
-        @requests.push(request.hashed_object)
-        self
+      requests.push(request.to_hash)
+      self
     end
 
-    def send
-
-      @kinto_client.post('/batch', @request_data)
+    def body
+      {
+        'defaults' => {
+          'method' => 'POST',
+          'path' => '/'
+        },
+        'requests' => requests
+      }
     end
-
   end
 end

--- a/lib/kinto_box/kinto_collection.rb
+++ b/lib/kinto_box/kinto_collection.rb
@@ -1,48 +1,15 @@
 require 'kinto_box/kinto_record'
-require 'kinto_box/kinto_object'
-require 'kinto_box/kinto_batch_request'
-
 module KintoBox
   class KintoCollection < KintoObject
+    child_class KintoRecord
 
+    alias_method :bucket, :parent
+    alias_method :record, :child
 
-    attr_reader :bucket
-
-    def initialize (bucket, collection_id)
-      raise ArgumentError if bucket.nil? || collection_id.nil?
-      @kinto_client = bucket.kinto_client
-      @bucket = bucket
-      @id = collection_id
-      @url_path = "/buckets/#{bucket.id}/collections/#{@id}"
-      @child_path = '/records'
-    end
-
-    def record (record_id)
-      KintoRecord.new(self, record_id)
-    end
-
-
-    def list_records(filters = nil, sort = nil)
-      @kinto_client.get(url_w_qsp(filters, sort))
-    end
-
-
-    def create_record(data)
-      resp = @kinto_client.post("#{@url_path}#{@child_path}", { 'data' => data})
-      record_id = resp['data']['id']
-      record(record_id)
-    end
-
-
-    def delete_records(filters = nil)
-      @kinto_client.delete(url_w_qsp(filters))
-    end
-
-
-    def count_records(filters = nil)
-      @kinto_client.head(url_w_qsp(filters))['Total-Records'].to_i
-    end
-
+    alias_method :create_record, :create_child
+    alias_method :list_records, :list_children
+    alias_method :delete_records, :delete_children
+    alias_method :count_records, :count_children
 
     alias_method :create_record_request, :create_child_request
     alias_method :list_records_request, :list_children_request

--- a/lib/kinto_box/kinto_group.rb
+++ b/lib/kinto_box/kinto_group.rb
@@ -1,34 +1,21 @@
 require 'kinto_box/kinto_object'
-
 module KintoBox
   class KintoGroup < KintoObject
-
-    attr_accessor :id
-    attr_reader :bucket
-
-    def initialize (bucket, group_id)
-      raise ArgumentError if bucket.nil? || group_id.nil?
-      @kinto_client = bucket.kinto_client
-      @bucket = bucket
-      @id = group_id
-      @url_path = "/buckets/#{bucket.id}/groups/#{@id}"
-    end
-
     def update_members(members)
       members = [members] unless members.is_a?(Array)
-      update({ 'members' => members })
+      update 'members' => members
     end
 
     def add_member(member)
       members = info['data']['members']
       members << member
-      update({ 'members' => members })
+      update 'members' => members
     end
 
     def remove_member(member)
       members = info['data']['members']
       members.delete(member)
-      update({ 'members' => members })
+      update 'members' => members
     end
   end
 end

--- a/lib/kinto_box/kinto_object.rb
+++ b/lib/kinto_box/kinto_object.rb
@@ -1,90 +1,226 @@
 module KintoBox
   class KintoObject
+    class << self
+      # Get the name of this class suitable for use in url path
+      def path_name
+        name.sub('KintoBox::Kinto', '').downcase + 's'
+      end
 
-    attr_accessor :id
-    attr_reader :url_path
-
-    def info
-      @kinto_client.get(@url_path)
+      # Assign or retrieve the child class
+      def child_class(value = nil)
+        return @child_class if value.nil?
+        @child_class = value
+      end
     end
 
-    def delete
-      @kinto_client.delete(@url_path)
+    attr_reader :id, :parent, :client
+
+    def initialize(client: nil, id: nil, parent: nil, info: nil)
+      @client = client || parent.client
+      @parent = parent
+      @id = id || (info ? info['data']['id'] : nil)
+      @info = info
+      self
     end
 
-    def update(data)
-      @kinto_client.patch(@url_path, {'data' => data})
+    # Get the path to this object in the Kinto API.
+    # This method uses the name of this class and whatever @parent.url_path is
+    # to create a partial url path.
+    # @return [String] URL fragment
+    def url_path
+      path = "/#{self.class.path_name}/#{id}"
+      path = parent.url_path + path unless parent.nil?
+      path.gsub(%r{/+}, '/')
     end
 
+    # Get the path to this object in the Kinto API
+    # Use the name of url_path and whatever the child class has set for @parent.url_path is
+    # to create a partial url path.
+    # @return [String] URL fragment
+    def child_path
+      return unless child_class?
+      "#{url_path}/#{child_class.path_name}".gsub(%r{/+}, '/')
+    end
+
+    # Check to see if this Kinto object exists
+    # @return [Boolean]
     def exists?
       begin
-        info
+        return false if info && info['data'] && info['data']['deleted'] == true
       rescue
         return false
       end
       true
     end
 
-    def info_request
-      KintoRequest.new('GET', @url_path)
+    # Get the data related to this object
+    # @return [Hash] Object data
+    def info
+      @info ||= info_request.execute
     end
 
-    def update_request(data)
-      KintoRequest.new('PATCH', @url_path, {'data' => data})
+    # Delete this object
+    # @return [Hash] Response
+    def delete
+      @info = delete_request.execute
     end
 
-    def delete_request
-      KintoRequest.new('DELETE', @url_path)
+    # Update this object
+    # @return [Hash] Response
+    def update(data)
+      @info = update_request(data).execute
     end
 
-    def create_child_request(data)
-      KintoRequest.new('POST', url_w_qsp, { 'data' => data})
+    # Replace all data in the object
+    # @return [Hash] Response
+    def replace(data)
+      @info = replace_request(data).execute
     end
 
-    def list_children_request(filters = nil, sort = nil)
-      KintoRequest.new('GET', url_w_qsp(filters, sort))
+    # Return an object for this child
+    # @param [String] Child object ID
+    # @return [KintoObject] Child for ID
+    def child(child_id)
+      child_class.new(id: child_id, parent: self)
     end
 
-    def delete_children_request(filters = nil)
-      KintoRequest.new('DELETE', url_w_qsp(filters))
+    # Create a child object
+    # @param [String] Child object ID
+    # @return [KintoObject] New child
+    def create_child(data)
+      resp = create_child_request(data).execute
+      child_class.new(info: resp, parent: self)
     end
 
-    def count_children_request(filters = nil)
-      KintoRequest.new('HEAD',  url_w_qsp(filters))
+    # Get all children
+    # @param [String,Array] Filters
+    # @param [String] Sort by
+    # @return [Hash] All children
+    def list_children(filters = nil, sort = nil)
+      list_children_request(filters, sort).execute
     end
 
+    # Get all children
+    # @param [String,Array] Filters
+    # @param [String] Sort by
+    # @return [Hash] All children
+    def delete_children(filters = nil)
+      delete_children_request(filters).execute
+    end
+
+    # Count all children
+    # @param [String,Array] Filters
+    # @return [Integer] Count
+    def count_children(filters = nil)
+      count_children_request(filters).execute['Total-Records'].to_i
+    end
+
+    # Add a permission to this object
+    # @param [String] Principal aka user or group name
+    # @param [String] Permission name i.e. read, write, etc
+    # @return [KintoObject] The current instance; for chaining
     def add_permission(principal, permission)
-      @kinto_client.patch(@url_path, {'permissions' => { permission => [principal_name(principal)] }})
+      @info = client.patch(url_path, 'permissions' => { permission => [principal_name(principal)] })
       self
     end
 
+    # Replace all permissions for this object
+    # @param [String] Principal aka user or group name
+    # @param [String] Permission name i.e. read, write, etc
+    # @return [KintoObject] The current instance; for chaining
     def replace_permission(principal, permission)
-      @kinto_client.put(@url_path, {'permissions' => { permission => [principal_name(principal)] }})
+      @info = client.put(url_path, 'permissions' => { permission => [principal_name(principal)] })
       self
     end
 
+    # Get the permissions for the current object
+    # @return [Hash] Hash of permissions and assigned principals.
     def permissions
       info['permissions']
     end
 
+    # Get a kinto request object for making an info request
+    # @return [KintoRequest] Object representing this request
+    def info_request
+      client.create_request('GET', url_path)
+    end
+
+    # Get a kinto request object for making an update request
+    # @param [Hash] Data
+    # @return [KintoRequest] Object representing this request
+    def update_request(data)
+      client.create_request('PATCH', url_path, 'data' => data)
+    end
+
+    # Get a kinto request object for making a delete request
+    # @param [Hash] Data
+    # @return [KintoRequest] Object representing this request
+    def replace_request(data)
+      client.create_request('PUT', url_path, 'data' => data)
+    end
+
+    # Get a kinto request object for making a delete request
+    # @return [KintoRequest] Object representing this request
+    def delete_request
+      client.create_request('DELETE', url_path)
+    end
+
+    # Get a kinto request object for making a create child request
+    # @return [KintoRequest] Object representing this request
+    def create_child_request(data)
+      client.create_request('POST', url_w_qsp, 'data' => data)
+    end
+
+    # Get a kinto request object for making a list children request
+    # @return [KintoRequest] Object representing this request
+    def list_children_request(filters = nil, sort = nil)
+      client.create_request('GET', url_w_qsp(filters, sort))
+    end
+
+    # Get a kinto request object for making a delete children request
+    # @return [KintoRequest] Object representing this request
+    def delete_children_request(filters = nil)
+      client.create_request('DELETE', url_w_qsp(filters))
+    end
+
+    # Get a kinto request object for making a count children request
+    # @return [KintoRequest] Object representing this request
+    def count_children_request(filters = nil)
+      client.create_request('HEAD', url_w_qsp(filters))
+    end
 
     private
 
+    # Get the class for this object's child
+    # @return [KintoObject] Child class
+    def child_class
+      self.class.child_class
+    end
+
+    # Does this class have a child class?
+    # @return [Boolean]
+    def child_class?
+      !(child_class.nil? || child_class.is_a?(KintoObject))
+    end
+
+    # Convert the principal name to something Kinto will like
+    # @return [String] Valid Kinto principal name
     def principal_name(principal)
       case principal.downcase
-        when 'authenticated'
-          return 'system.Authenticated'
-        when 'anonymous'
-          return 'system.Everyone'
-        when 'everyone'
-          return 'system.Everyone'
-        else
-          return principal
+      when 'authenticated'
+        'system.Authenticated'
+      when 'anonymous'
+        'system.Everyone'
+      when 'everyone'
+        'system.Everyone'
+      else
+        principal
       end
     end
 
+    # Build the path including querystring
     def url_w_qsp(filters = nil, sort = nil, add_child = true)
-      url = @child_path.nil? || !add_child ? @url_path : "#{@url_path}#{@child_path}"
+      url = child_path.nil? || !add_child ? url_path : child_path
       query_string = ''
       query_string = filters unless filters.nil?
       query_string = "#{query_string}&" unless filters.nil? || sort.nil?

--- a/lib/kinto_box/kinto_object.rb
+++ b/lib/kinto_box/kinto_object.rb
@@ -59,6 +59,11 @@ module KintoBox
       @info ||= info_request.execute
     end
 
+    # Delete the cached info for this object
+    def reload
+      @info = nil
+    end
+
     # Delete this object
     # @return [Hash] Response
     def delete

--- a/lib/kinto_box/kinto_record.rb
+++ b/lib/kinto_box/kinto_record.rb
@@ -1,17 +1,5 @@
 require 'kinto_box/kinto_object'
 module KintoBox
   class KintoRecord < KintoObject
-    attr_reader :id
-    def initialize (collection, record_id)
-      raise ArgumentError if collection.nil? || record_id.nil?
-      @kinto_client = collection.bucket.kinto_client
-      @id = record_id
-      @url_path = "/buckets/#{collection.bucket.id}/collections/#{collection.id}/records/#{@id}"
-      @child_path = nil
-    end
-
-    def replace(data)
-      @kinto_client.put(@url_path, {'data' => data})
-    end
   end
 end

--- a/lib/kinto_box/kinto_request.rb
+++ b/lib/kinto_box/kinto_request.rb
@@ -1,18 +1,21 @@
 module KintoBox
   class KintoRequest
+    attr_reader :method, :path, :body, :headers
 
-    def initialize(method = 'GET', path = nil , body = {}, headers = nil)
+    def initialize(client, method, path, body = {}, headers: nil)
+      @client = client
       @method = method
       @path = path
       @body = body
       @headers = headers
     end
 
-    def hashed_object
-      { 'method' => @method,
-        'path' => @path,
-        'body' => @body
-      }
+    def to_hash
+      { 'method' => method, 'path' => path, 'body' => body }
+    end
+
+    def execute
+      @client.send_request(self)
     end
   end
 end

--- a/lib/kinto_box/kinto_server.rb
+++ b/lib/kinto_box/kinto_server.rb
@@ -1,0 +1,31 @@
+require 'kinto_box/kinto_bucket'
+module KintoBox
+  class KintoServer < KintoObject
+    child_class KintoBox::KintoBucket
+
+    alias_method :bucket, :child
+
+    alias_method :list_buckets, :list_children
+    alias_method :delete_buckets, :delete_children
+    alias_method :count_buckets, :count_children
+
+    alias_method :create_bucket_request, :create_child_request
+    alias_method :list_bucket_request, :list_children_request
+    alias_method :delete_buckets_request, :delete_children_request
+    alias_method :count_buckets_request, :count_children_request
+
+    def url_path
+      '/'
+    end
+
+    # Get current user id
+    # @return [String] current user id
+    def current_user_id
+      info['user']['id']
+    end
+
+    def create_bucket(id)
+      create_child(id: id)
+    end
+  end
+end

--- a/lib/kinto_box/version.rb
+++ b/lib/kinto_box/version.rb
@@ -1,3 +1,3 @@
 module KintoBox
-  VERSION = "0.1.12"
+  VERSION = '0.2.0'.freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,8 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'minitest/autorun'
 require 'kinto_box'
 
-KINTO_SERVER = 'https://kinto.dev.mozaws.net'
+KINTO_SERVER = 'https://kinto.dev.mozaws.net'.freeze
 
-def random_string (n = 8)
-  [*('a'..'z'),*('0'..'9')].to_a.shuffle[0,n].join
+def random_string(n = 8)
+  [*('a'..'z'), *('0'..'9')].to_a.shuffle[0, n].join
 end


### PR DESCRIPTION
Made a bunch of changes to try to simplify stuff.
- The KintoObject does much more now, KintoServer, KintoCollection, KintoBucket and KintoRecord all inherit from KintoObject. This eliminated some duplication from these classes and from the base KintoClient class which was doing what KintoServer does now.
- Almost all requests now use the KintoRequest object. While this makes the single requests more complex, it unites the code paths between batch requests and single requests.
- Renamed the `send` method in KintoRequest to `execute`. `send` is a core ruby api method.
- KintoBatchRequest now inherits from KintoRequest. All request objects have an `execute` method.
- KintoObject `info` responses are now cached. This will probably cause some trouble checking if something changed the data on the server outside of the object instance. Added a `reload` method to KintoObject to bust this cache.
- Added a rubocop config and fixed most rubocop warnings and errors.